### PR TITLE
Fix the sensor model to match the reference implementation

### DIFF
--- a/src/gymnasium_hardmaze/envs/components/radar.py
+++ b/src/gymnasium_hardmaze/envs/components/radar.py
@@ -1,36 +1,56 @@
 """Radar component for detecting the goal in maze environments."""
 
+# How far the detection wedge is drawn, in environment units. Rendering only --
+# the radar has no range limit (see `Radar`).
+DISPLAY_RANGE = 100.0
+
 
 class Radar:
-    """Radar sensor for detecting objects within an angular range.
+    """Radar sensor reporting which quadrant the goal lies in.
 
-    The radar detects whether a target is within its detection range
-    and angular field of view.
+    Detection is purely angular and has no distance limit: the radar fires
+    whenever the goal falls inside its wedge, however far away it is. So exactly
+    one radar of a full set is lit at any moment, and together they act as a
+    coarse compass pointing at the goal rather than a proximity sensor.
+
+    This matches the reference implementation, whose `PieSliceSensorArray.update`
+    computes the bearing to the goal and lights the matching wedge without
+    consulting distance at all. A range limit would leave the whole array dark
+    for most of the hard maze -- the goal sits roughly 236 units from the start
+    -- depriving a controller of any signal about where it is meant to go.
 
     Attributes:
-        start_angle (float): Starting angle of the detection arc (radians).
-        end_angle (float): Ending angle of the detection arc (radians).
-        max_range (float): Maximum detection distance.
+        start_angle (float): Starting angle of the detection arc (radians),
+            relative to the robot's heading.
+        end_angle (float): Ending angle of the detection arc (radians),
+            relative to the robot's heading.
+        display_range (float): Length the wedge is drawn at. Rendering only;
+            it does not affect detection.
         detecting (int): Binary value indicating detection (0 or 1).
     """
 
-    def __init__(self, start_angle: float, end_angle: float, max_range: float = 100.0):
+    def __init__(
+        self,
+        start_angle: float,
+        end_angle: float,
+        display_range: float = DISPLAY_RANGE,
+    ):
         """Initialize a radar sensor.
 
         Args:
             start_angle: Starting angle of the detection arc (radians).
             end_angle: Ending angle of the detection arc (radians).
-            max_range: Maximum detection distance.
+            display_range: Length the wedge is drawn at; rendering only.
         """
         self.start_angle = start_angle
         self.end_angle = end_angle
-        self.max_range = max_range
+        self.display_range = display_range
         self.detecting = 0
 
     def get_value(self) -> int:
         """Get the current detection value.
 
         Returns:
-            int: 1 if target detected, 0 otherwise.
+            int: 1 if the goal is inside this radar's wedge, 0 otherwise.
         """
         return self.detecting

--- a/src/gymnasium_hardmaze/envs/components/rangefinder.py
+++ b/src/gymnasium_hardmaze/envs/components/rangefinder.py
@@ -1,40 +1,69 @@
 """Rangefinder component for distance sensing in maze environments."""
 
+# Readings at or below this, after normalization, are reported as 0.0.
+#
+# From the reference implementation's `Khepera3RobotModel.doAction`, which
+# clamps each rangefinder to 1.0 and then applies `if (inputs[j] <= floor)
+# inputs[j] = 0.0f` with `floor = 0.25f`. The near field is therefore not
+# merely "close", it is invisible, and a controller cannot distinguish a wall
+# at the robot's skin from a wall 10 units out.
+SENSOR_FLOOR = 0.25
+
 
 class RangeFinder:
     """Distance sensor for detecting obstacles.
 
     Measures the distance to the nearest obstacle in its line of sight.
 
+    Distances are measured from the robot's centre, so a reading is never
+    smaller than the robot's own radius. Normalization subtracts that radius
+    before scaling, which is what puts a reading of 0.0 at the robot's skin and
+    1.0 at the far end of its sensing range, rather than leaving the bottom
+    quarter of the range permanently unreachable.
+
     Attributes:
         angle (float): Sensor orientation relative to robot heading (radians).
-        max_range (float): Maximum detection distance.
-        distance (float): Current measured distance, -1 if nothing detected.
+        actual_range (float): Sensing range measured out from the robot's skin.
+        robot_size (float): Radius of the robot the sensor is mounted on.
+        max_range (float): Furthest measurable distance from the robot's centre,
+            i.e. ``actual_range + robot_size``. This is how far rays are cast
+            and the value a reading saturates at.
+        distance (float): Current measured distance from the centre, -1 if the
+            sensor has not been updated yet.
     """
 
-    def __init__(self, angle: float, max_range: float):
+    def __init__(self, angle: float, actual_range: float, robot_size: float):
         """Initialize a rangefinder sensor.
 
         Args:
             angle: Sensor orientation relative to robot heading (radians).
-            max_range: Maximum detection distance.
+            actual_range: Sensing range out from the robot's skin.
+            robot_size: Radius of the robot carrying the sensor.
         """
         self.angle = angle
-        self.max_range = max_range
+        self.actual_range = actual_range
+        self.robot_size = robot_size
+        self.max_range = actual_range + robot_size
         self.distance = -1.0
 
     def get_value(self) -> float:
         """Get the normalized distance value.
 
+        Discounts the robot's own radius, saturates at 1.0, and floors small
+        readings to 0.0 (see :data:`SENSOR_FLOOR`).
+
         Returns:
             float: Normalized distance in range [0, 1].
         """
-        return self.distance / self.max_range
+        value = min((self.distance - self.robot_size) / self.actual_range, 1.0)
+        if value <= SENSOR_FLOOR:
+            value = 0.0
+        return value
 
     def get_value_raw(self) -> float:
         """Get the raw distance value.
 
         Returns:
-            float: Measured distance in environment units.
+            float: Measured distance from the robot's centre, in environment units.
         """
         return self.distance

--- a/src/gymnasium_hardmaze/envs/components/robot.py
+++ b/src/gymnasium_hardmaze/envs/components/robot.py
@@ -8,6 +8,24 @@ from typing import List, Tuple
 from .radar import Radar
 from .rangefinder import RangeFinder
 
+# Half the angular spread of the rangefinder array, in radians.
+#
+# The reference spaces its rangefinders evenly across [-1.3398, 1.3398], i.e.
+# +/-76.8 degrees, so the outermost pair look forward-and-out rather than
+# straight out to the sides. Widening this to +/-90 degrees costs the robot
+# forward coverage in the corridors it has to thread.
+SENSOR_HALF_SPREAD = 1.3398
+
+# Heading the robot starts at, in radians.
+#
+# The reference's environment file records `robot_heading` 0, and that is not
+# the value it runs: `hardmaze_exp.xml` sets `overrideTeamFormation`, so
+# `initializeRobots` reads the *experiment's* `robot_heading` of 270 degrees
+# instead. Headings here are signed the opposite way (see `update_position`,
+# which subtracts its y component), so the reference's 270 degrees is +pi/2
+# here. Both point the robot up the map, toward the goal.
+DEFAULT_START_HEADING = math.pi / 2
+
 
 class Robot:
     """Robot agent that navigates through the maze environment.
@@ -42,6 +60,7 @@ class Robot:
         heading_noise: float = 0.0,
         effector_noise: float = 0.0,
         sensor_noise: float = 0.0,
+        heading: float = DEFAULT_START_HEADING,
     ):
         """Initialize a robot agent with sensors.
 
@@ -50,11 +69,13 @@ class Robot:
             num_rangefinders: Number of rangefinder sensors.
             num_radars: Number of radar sensors.
             robot_size: Radius of the robot for collision detection.
-            range_distance: Maximum detection range for sensors.
+            range_distance: Sensing range measured out from the robot's skin.
             time_step: Time increment for movement updates.
             heading_noise: Amount of noise in heading changes (0-100).
             effector_noise: Amount of noise in effector changes (0-100).
             sensor_noise: Amount of noise in sensor changes (0-100).
+            heading: Initial heading in radians. See
+                :data:`DEFAULT_START_HEADING`.
         """
         self.name = "MazeRobotPieSlice"
         self.default_speed = 25.0
@@ -62,7 +83,7 @@ class Robot:
         self.actualRange = range_distance
         self.default_robot_size = robot_size
         self.velocity = 0.0
-        self.heading = math.pi / 2
+        self.heading = heading
         self.location = location
         self.old_location = location
         self.time_step = time_step
@@ -83,18 +104,30 @@ class Robot:
                 RuntimeWarning,
             )
 
-        # Initialize rangefinders
+        # Rangefinders, spread evenly across the forward arc from left to right.
+        # A lone sensor looks straight ahead rather than sitting at one end of
+        # the arc, which is where an even spread of one would otherwise put it.
         self.rangefinders: List[RangeFinder] = []
-        for i in range(num_rangefinders):
-            between_angle = math.pi / 4.0
-            final_angle = math.pi / 2 - (between_angle * i)
-            self.rangefinders.append(RangeFinder(final_angle, self.actualRange))
+        if num_rangefinders == 1:
+            angles = [0.0]
+        else:
+            spacing = 2.0 * SENSOR_HALF_SPREAD / (num_rangefinders - 1)
+            angles = [SENSOR_HALF_SPREAD - spacing * i for i in range(num_rangefinders)]
+        for final_angle in angles:
+            self.rangefinders.append(
+                RangeFinder(final_angle, self.actualRange, self.default_robot_size)
+            )
 
-        # Initialize radars
+        # Radars, tiling the full circle. Index 0 straddles dead ahead, and the
+        # rest follow round, so the array reads as a compass: front, then each
+        # side in turn, then behind. The reference orders its wedges the same
+        # way, which matters because HyperNEAT-style controllers read geometry
+        # off the input layout -- shifting the array by one quadrant silently
+        # relabels "the goal is ahead" as "the goal is off to one side".
         self.radars: List[Radar] = []
         for i in range(num_radars):
-            between_angle = math.pi / 2.0
-            start_angle = math.pi / 4 - (between_angle * i)
+            between_angle = 2.0 * math.pi / num_radars
+            start_angle = -between_angle / 2.0 - (between_angle * i)
             self.radars.append(Radar(start_angle, start_angle + between_angle))
 
     def rand_bool(self) -> bool:
@@ -178,9 +211,7 @@ class Robot:
         for finder in self.rangefinders:
             a1x = self.location[0]
             a1y = self.location[1]
-            finder.distance = raycast(
-                walls, finder, a1x, a1y, self.heading, self.default_robot_size
-            )
+            finder.distance = raycast(walls, finder, a1x, a1y, self.heading)
 
     def update_radars(self, goal) -> None:
         """Update radar readings based on goal position.
@@ -193,10 +224,7 @@ class Robot:
         )
 
         for radar in self.radars:
-            r_range = radar.max_range
             start_angle = self.heading + radar.start_angle
             end_angle = self.heading + radar.end_angle
             x, y = self.location
-            radar.detecting = int(
-                radar_detect(goal, x, y, start_angle, end_angle, r_range)
-            )
+            radar.detecting = int(radar_detect(goal, x, y, start_angle, end_angle))

--- a/src/gymnasium_hardmaze/envs/environment.py
+++ b/src/gymnasium_hardmaze/envs/environment.py
@@ -61,6 +61,11 @@ class Environment:
             float(robot_spacing_tag.get_text()) if robot_spacing_tag else 30.0
         )
 
+        # Recorded for completeness; deliberately NOT used to place the robot.
+        # The reference overrides this file's value from its experiment config
+        # (see `DEFAULT_START_HEADING` in components.robot), and hardmaze_env.xml
+        # stores 0 -- which would aim the robot along +x, into the wall beside
+        # it, instead of up the map toward the goal.
         heading_tag = cast(Optional[Tag], soup.find("robot_heading"))
         self.heading: float = float(heading_tag.get_text()) if heading_tag else 0.0
 

--- a/src/gymnasium_hardmaze/envs/maze_env.py
+++ b/src/gymnasium_hardmaze/envs/maze_env.py
@@ -335,14 +335,20 @@ class HardMazeEnvV0(MazeEnv):
     The observation space is a `Box(0, 1, (9,), float32)`, which is a concatenation of
     the robot's sensor readings:
 
-    - **5 Rangefinders:** These sensors are distributed symmetrically across the robot's
-      front, from -90 to +90 degrees. They return the normalized distance to the
-      nearest wall in their line of sight. A value of `1.0` means no wall is
-      detected within max range, while `0.0` indicates a wall is very close.
-    - **4 Radar "Pie-Slices":** These sensors detect the goal. They divide the
-      robot's forward view into four 90-degree arcs. Each sensor returns a binary
-      value (`0.0` or `1.0`) indicating whether the goal is within its angular
-      range and maximum detection distance.
+    - **5 Rangefinders:** Distributed symmetrically across the robot's front, from
+      +76.8 to -76.8 degrees, ordered left to right. They return the normalized
+      distance to the nearest wall in their line of sight. Distance is measured
+      from the robot's centre and the robot's own radius is discounted, so `1.0`
+      means nothing was found within the 40-unit sensing range and `0.0` means a
+      wall is close. Anything normalizing to `0.25` or below is reported as
+      exactly `0.0`, so the near field reads as a single "blocked" state rather
+      than a graded one.
+    - **4 Radar "Pie-Slices":** These sensors report *which way the goal lies*, not
+      how near it is. They divide the full circle into four 90-degree wedges --
+      index 0 straddles dead ahead, and the rest follow round the robot -- and each
+      returns a binary value indicating whether the goal falls inside its wedge.
+      There is no maximum detection distance, so exactly one of the four is lit at
+      all times and together they act as a coarse compass.
 
     ## Rewards
 
@@ -362,7 +368,8 @@ class HardMazeEnvV0(MazeEnv):
     ## Starting State
 
     The robot starts at a fixed position `(205, 387)` at the bottom of the maze, with a
-    fixed heading of 90 degrees (facing upwards).
+    fixed heading of 90 degrees (facing upwards). The `robot_heading` recorded in the
+    maze XML is not used; see `DEFAULT_START_HEADING` in `envs.components.robot`.
 
     ## Episode End
 

--- a/src/gymnasium_hardmaze/envs/rendering/renderer.py
+++ b/src/gymnasium_hardmaze/envs/rendering/renderer.py
@@ -85,7 +85,7 @@ class Renderer:
             heading: Robot heading in radians.
             radar: Radar object.
         """
-        length = radar.max_range
+        length = radar.display_range
         start_angle = heading + radar.start_angle
         end_angle = heading + radar.end_angle
         ray_color = (200, 50, 0) if radar.detecting > 0 else (200, 200, 200)

--- a/src/gymnasium_hardmaze/envs/utils/utils.py
+++ b/src/gymnasium_hardmaze/envs/utils/utils.py
@@ -147,9 +147,14 @@ def raycast(
     a1x: float,
     a1y: float,
     heading: float,
-    radius: float,
 ) -> float:
     """Cast a ray and find the distance to the nearest wall.
+
+    The ray runs from the robot's centre out to ``finder.max_range``, and a hit
+    beyond that is not a hit at all, so the cast length and the saturation
+    distance are necessarily the same number. Casting further than the sensor
+    can report would find walls it then has to discard; reporting further than
+    the cast would claim a range that was never searched.
 
     Args:
         walls: List of walls to check for intersection.
@@ -157,13 +162,13 @@ def raycast(
         a1x: X-coordinate of ray origin.
         a1y: Y-coordinate of ray origin.
         heading: Current heading angle in radians.
-        radius: Radius to add to the origin point.
 
     Returns:
-        float: Distance to the nearest wall or max_range if none found.
+        float: Distance to the nearest wall, or ``finder.max_range`` if the ray
+        reaches that far without hitting one.
     """
     shortest_distance = finder.max_range
-    length = radius + finder.max_range
+    length = finder.max_range
     angle = heading + finder.angle
     a2x = a1x + length * math.cos(angle)
     a2y = a1y - length * math.sin(angle)
@@ -204,9 +209,11 @@ def radar_detect(
     y: float,
     start_angle: float,
     end_angle: float,
-    r_range: float,
 ) -> float:
-    """Check if goal is within radar detection range and angle.
+    """Check whether the goal lies inside a radar's angular wedge.
+
+    Bearing only -- distance is deliberately not consulted. See :class:`Radar`
+    for why the reference's goal sensor has no range limit.
 
     Args:
         goal: Goal object with x, y coordinates.
@@ -214,16 +221,12 @@ def radar_detect(
         y: Y-coordinate of radar origin.
         start_angle: Start angle of radar arc in radians.
         end_angle: End angle of radar arc in radians.
-        r_range: Maximum detection range.
 
     Returns:
         float: 1.0 if goal detected, 0.0 otherwise.
     """
     start_angle = normalize(start_angle)
     end_angle = normalize(end_angle)
-
-    if distance(x, y, goal.x, goal.y) > r_range:
-        return 0.0
 
     angle = normalize(math.atan2(-(goal.y - y), (goal.x - x)))
 

--- a/src/gymnasium_hardmaze/tests/test_sensor_model.py
+++ b/src/gymnasium_hardmaze/tests/test_sensor_model.py
@@ -1,0 +1,169 @@
+"""Tests for the robot's sensor model.
+
+These pin the properties that make the sensors usable, each of which was wrong
+at some point and each of which fails quietly rather than loudly: a rangefinder
+that can never read 0, a goal sensor that is dark for most of the maze, a radar
+array rotated by one quadrant. None of these raise; they just make the task
+unlearnable, so they need tests that assert on values rather than on shapes.
+"""
+
+import math
+
+import pytest
+
+from gymnasium_hardmaze.envs.components.goal import Goal
+from gymnasium_hardmaze.envs.components.rangefinder import SENSOR_FLOOR, RangeFinder
+from gymnasium_hardmaze.envs.components.robot import (
+    DEFAULT_START_HEADING,
+    SENSOR_HALF_SPREAD,
+    Robot,
+)
+from gymnasium_hardmaze.envs.components.wall import Wall
+
+ROBOT_SIZE = 10.5
+ACTUAL_RANGE = 40.0
+
+
+def make_finder(distance: float) -> RangeFinder:
+    finder = RangeFinder(0.0, ACTUAL_RANGE, ROBOT_SIZE)
+    finder.distance = distance
+    return finder
+
+
+# -- rangefinder normalization ------------------------------------------------
+
+
+def test_rangefinder_reaches_one_at_the_far_end_of_its_range():
+    """Nothing in sight must read exactly 1.0, not 40/50.5."""
+    finder = make_finder(ACTUAL_RANGE + ROBOT_SIZE)
+    assert finder.get_value() == pytest.approx(1.0)
+
+
+def test_rangefinder_reaches_zero_at_the_robots_skin():
+    """A wall touching the robot must read 0.0.
+
+    Distances are measured from the centre, so without discounting the radius
+    the lowest achievable reading would be 10.5/50.5, and the bottom fifth of
+    the range would be unreachable.
+    """
+    assert make_finder(ROBOT_SIZE).get_value() == pytest.approx(0.0)
+
+
+def test_rangefinder_saturates_rather_than_exceeding_one():
+    assert make_finder(1000.0).get_value() == pytest.approx(1.0)
+
+
+def test_rangefinder_floors_near_readings_to_zero():
+    """Anything normalizing to <= 0.25 collapses to 0.0."""
+    just_under = ROBOT_SIZE + ACTUAL_RANGE * SENSOR_FLOOR - 1e-9
+    just_over = ROBOT_SIZE + ACTUAL_RANGE * (SENSOR_FLOOR + 0.05)
+    assert make_finder(just_under).get_value() == 0.0
+    assert make_finder(just_over).get_value() > 0.0
+
+
+def test_rangefinder_max_range_includes_the_robot_radius():
+    finder = RangeFinder(0.0, ACTUAL_RANGE, ROBOT_SIZE)
+    assert finder.max_range == pytest.approx(ACTUAL_RANGE + ROBOT_SIZE)
+
+
+def test_rangefinder_reports_a_wall_beyond_forty_units():
+    """A wall between 40 and 50.5 units out is visible.
+
+    Capping reported distance at the sensing range while casting the ray the
+    full distance from the centre would discard exactly this band.
+    """
+    robot = Robot((0.0, 0.0), heading=0.0)
+    walls = [Wall(45.0, -100.0, 45.0, 100.0)]
+    robot.update_rangefinders(walls)
+    middle = robot.rangefinders[len(robot.rangefinders) // 2]
+    assert middle.get_value_raw() == pytest.approx(45.0)
+    assert 0.0 < middle.get_value() < 1.0
+
+
+# -- rangefinder geometry -----------------------------------------------------
+
+
+def test_rangefinders_span_the_reference_arc_left_to_right():
+    robot = Robot((0.0, 0.0))
+    angles = [finder.angle for finder in robot.rangefinders]
+    assert angles[0] == pytest.approx(SENSOR_HALF_SPREAD)
+    assert angles[-1] == pytest.approx(-SENSOR_HALF_SPREAD)
+    assert angles == sorted(angles, reverse=True), "must run left to right"
+    assert angles[len(angles) // 2] == pytest.approx(0.0), "middle looks ahead"
+
+
+def test_rangefinders_are_evenly_spaced():
+    robot = Robot((0.0, 0.0), num_rangefinders=5)
+    angles = [finder.angle for finder in robot.rangefinders]
+    gaps = [a - b for a, b in zip(angles, angles[1:])]
+    assert gaps == pytest.approx([gaps[0]] * len(gaps))
+
+
+def test_a_single_rangefinder_looks_straight_ahead():
+    robot = Robot((0.0, 0.0), num_rangefinders=1)
+    assert robot.rangefinders[0].angle == pytest.approx(0.0)
+
+
+# -- radar --------------------------------------------------------------------
+
+
+def bearing_case(dx: float, dy: float, heading: float = 0.0):
+    """Light the radars for a goal offset ``(dx, dy)`` from the robot."""
+    robot = Robot((0.0, 0.0), heading=heading)
+    robot.update_radars(Goal(dx, dy))
+    return [radar.get_value() for radar in robot.radars]
+
+
+def test_exactly_one_radar_is_lit():
+    """The wedges tile the circle without gaps or overlap."""
+    for degrees in range(0, 360, 7):
+        radians = math.radians(degrees)
+        # y is negated: the package measures bearings counterclockwise on a
+        # screen whose y axis points down.
+        lit = bearing_case(200.0 * math.cos(radians), -200.0 * math.sin(radians))
+        assert sum(lit) == 1, f"bearing {degrees} lit {lit}"
+
+
+def test_radar_zero_looks_dead_ahead():
+    """Index 0 must straddle the heading, not start at it.
+
+    The array is read as a compass, and rotating it by a quadrant relabels
+    "the goal is ahead" as "the goal is off to one side".
+    """
+    assert bearing_case(200.0, 0.0)[0] == 1
+    assert bearing_case(200.0, -40.0)[0] == 1, "just left of straight ahead"
+    assert bearing_case(200.0, 40.0)[0] == 1, "just right of straight ahead"
+    assert bearing_case(-200.0, 0.0)[0] == 0, "directly behind"
+
+
+def test_radar_has_no_range_limit():
+    """Distance must not gate detection.
+
+    The goal starts roughly 236 units from the robot, so a 100-unit limit would
+    leave the whole array dark for most of an episode.
+    """
+    near = bearing_case(30.0, 0.0)
+    far = bearing_case(5000.0, 0.0)
+    assert near == far
+    assert sum(far) == 1
+
+
+def test_radar_tracks_the_robots_heading():
+    """A goal dead ahead stays on radar 0 whichever way the robot faces."""
+    for degrees in range(0, 360, 15):
+        heading = math.radians(degrees)
+        dx, dy = 300.0 * math.cos(heading), -300.0 * math.sin(heading)
+        assert bearing_case(dx, dy, heading=heading)[0] == 1
+
+
+# -- starting pose ------------------------------------------------------------
+
+
+def test_robot_starts_facing_up_the_map():
+    """Forward thrust from the start must decrease y (move up the screen)."""
+    robot = Robot((205.0, 387.0))
+    assert robot.heading == pytest.approx(DEFAULT_START_HEADING)
+    robot.decide_action([0.0, 1.0, 0.0], robot.time_step)
+    robot.update_position()
+    assert robot.location[1] < 387.0
+    assert robot.location[0] == pytest.approx(205.0, abs=1e-9)


### PR DESCRIPTION
The rangefinders and goal radar diverged from Risi's HyperSharpNEAT in ways that quietly cost the agent information rather than raising anything. Each is corrected here against the C# sources.

Rangefinders:

* Normalization discounts the robot's own radius. Distances are measured from the centre, so the previous `distance / max_range` could never fall below 10.5/50.5 and the bottom fifth of the range was unreachable. A wall touching the robot now reads 0.0 and open space reads 1.0.
* Readings normalizing to 0.25 or below now report exactly 0.0, matching `Khepera3RobotModel.doAction`'s floor.
* `max_range` includes the radius, so the cast length and the saturation distance agree. Previously rays were cast 50.5 units but hits were capped at 40, discarding every wall in the band between.
* The array spans +/-76.8 degrees rather than +/-90, so the outermost pair look forward-and-out. The wider spread cost forward coverage in the corridors.

Radar:

* Detection is angular only. It previously required the goal within 100 units, but the goal sits ~236 units from the start, so the whole array was dark for most of an episode and the agent had no signal about where it was headed. `PieSliceSensorArray.update` consults bearing alone.
* Wedge 0 now straddles dead ahead instead of starting there. The array is read as a compass and was rotated by one quadrant, relabelling "the goal is ahead" as "the goal is off to one side" -- which matters to any controller that reads geometry off the input layout.
* `max_range` is renamed `display_range`, since it only sets how far the wedge is drawn.

Also: a lone rangefinder now looks straight ahead rather than landing at one end of the arc, the robot's starting heading is an explicit documented parameter, and the unused `Environment.heading` is marked as deliberately not applied -- the reference overrides that file's value from its experiment config, and the recorded 0 would aim the robot into the wall beside it.

Note that the reference's own radar is not corrected here. Its `PieSliceSensorArray` computes a rotation in degrees and hands it to a routine that reads radians, so its "compass" is a scrambled function of the true bearing that magnifies heading changes 57-fold. This implements what that code is trying to compute. Controllers evolved against the original therefore will not transfer.

Verified by simulating an identical 455-step action sequence here and in a direct transcription of the C# with only that unit bug repaired: positions and all nine sensor readings agree exactly, to the last bit, at every step.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
