### PR TITLE
Add radar_model='reference': the original's scrambled goal sensor

### DIFF
--- a/src/gymnasium_hardmaze/envs/components/robot.py
+++ b/src/gymnasium_hardmaze/envs/components/robot.py
@@ -8,6 +8,31 @@ from typing import List, Tuple
 from .radar import Radar
 from .rangefinder import RangeFinder
 
+#: Radar models. ``corrected`` computes the bearing to the target the way
+#: the sensor is plainly meant to; ``reference`` reproduces the arithmetic
+#: of the original C# ``PieSliceSensorArray.update``, which works its
+#: rotation out in *degrees* and hands it to a rotate() that reads
+#: *radians*. That scales the heading by 180/3.14 ~ 57, so the array is not
+#: a goal-bearing compass but a deterministic scrambling of one: sweeping
+#: the heading through a full turn changes the lit wedge 229 times instead
+#: of 4. Risi's published champions were evolved against the scrambled
+#: sensor, so reproducing his results requires it -- see the sensor-model
+#: note in the README.
+RADAR_MODELS = ("corrected", "reference")
+
+#: Wedge bounds in degrees for the reference model, in the C#'s own order:
+#: front (straddling zero), left, rear, right.
+REFERENCE_RADAR_BINS = ((315.0, 405.0), (45.0, 135.0), (135.0, 225.0), (225.0, 315.0))
+
+
+def _reference_point_angle(x: float, y: float) -> float:
+    """``Point2D.angle`` from the reference: atan over a half turn, pi as 3.14."""
+    if x == 0.0:
+        return 3.14 / 2.0 if y > 0 else 3.14 * 3.0 / 2.0
+    angle = math.atan(y / x)
+    return angle if x > 0 else angle + 3.14
+
+
 # Half the angular spread of the rangefinder array, in radians.
 #
 # The reference spaces its rangefinders evenly across [-1.3398, 1.3398], i.e.
@@ -61,6 +86,7 @@ class Robot:
         effector_noise: float = 0.0,
         sensor_noise: float = 0.0,
         heading: float = DEFAULT_START_HEADING,
+        radar_model: str = "corrected",
     ):
         """Initialize a robot agent with sensors.
 
@@ -76,7 +102,17 @@ class Robot:
             sensor_noise: Amount of noise in sensor changes (0-100).
             heading: Initial heading in radians. See
                 :data:`DEFAULT_START_HEADING`.
+            radar_model: ``"corrected"`` or ``"reference"``; see
+                :data:`RADAR_MODELS`.
+
+        Raises:
+            ValueError: If ``radar_model`` is not a known model.
         """
+        if radar_model not in RADAR_MODELS:
+            raise ValueError(
+                f"radar_model must be one of {RADAR_MODELS}, got {radar_model!r}"
+            )
+        self.radar_model = radar_model
         self.name = "MazeRobotPieSlice"
         self.default_speed = 25.0
         self.default_turn_speed = 9.0
@@ -219,6 +255,10 @@ class Robot:
         Args:
             goal: Goal object to detect.
         """
+        if self.radar_model == "reference":
+            self._update_radars_reference(goal)
+            return
+
         from gymnasium_hardmaze.envs.utils import (  # Import here to avoid circular imports
             radar_detect,
         )
@@ -228,3 +268,26 @@ class Robot:
             end_angle = self.heading + radar.end_angle
             x, y = self.location
             radar.detecting = int(radar_detect(goal, x, y, start_angle, end_angle))
+
+    def _update_radars_reference(self, goal) -> None:
+        """The original ``PieSliceSensorArray.update``, arithmetic intact.
+
+        The rotation amount is computed in degrees and then used as radians,
+        magnifying the heading by 180/3.14. Kept verbatim rather than
+        corrected: the reference's champions were selected against this
+        sensor, and "fixing" it changes what the task is.
+        """
+        gx, gy = float(int(goal.x)), float(int(goal.y))
+        x, y = self.location
+
+        rotation = -(self.heading * 180.0 / 3.14)  # degrees ...
+        cos_a, sin_a = math.cos(rotation), math.sin(rotation)  # ... used as radians
+        ox, oy = gx - x, gy - y
+        rotated_x = cos_a * ox - sin_a * oy + x
+        rotated_y = sin_a * ox + cos_a * oy + y
+
+        angle = _reference_point_angle(rotated_x - x, rotated_y - y) * 57.297
+        for radar, (low, high) in zip(self.radars, REFERENCE_RADAR_BINS):
+            radar.detecting = int(
+                (low <= angle < high) or (low <= angle + 360.0 < high)
+            )

--- a/src/gymnasium_hardmaze/envs/dual_task_env.py
+++ b/src/gymnasium_hardmaze/envs/dual_task_env.py
@@ -130,6 +130,8 @@ class DualTaskEnvV0(gym.Env, EzPickle):
     - `max_steps`: Steps per scenario before truncation.
     - `food_placement`: `"fixed"` (the file's four positions, reproducible)
       or `"random"` (uniform inside the room each episode, the paper's rule).
+    - `radar_model`: `"corrected"` (a clean food compass) or `"reference"`
+      (the original's scrambled pie-slice sensor).
     """
 
     metadata = {"render_modes": [], "render_fps": 30}
@@ -141,6 +143,7 @@ class DualTaskEnvV0(gym.Env, EzPickle):
         max_steps: int = DEFAULT_EVALUATION_STEPS,
         render_mode: Optional[str] = None,
         food_placement: str = "fixed",
+        radar_model: str = "corrected",
     ):
         """Initialize the dual task environment.
 
@@ -154,6 +157,9 @@ class DualTaskEnvV0(gym.Env, EzPickle):
             food_placement: ``"fixed"`` replays the world file's four food
                 positions; ``"random"`` draws them uniformly inside the room
                 each episode, which is what the paper describes.
+            radar_model: ``"corrected"`` (a clean food compass) or
+                ``"reference"`` (the original's degrees-as-radians sensor,
+                which the published champions were evolved against).
 
         Raises:
             ValueError: If ``scenario`` or ``food_placement`` is unknown, or
@@ -162,7 +168,13 @@ class DualTaskEnvV0(gym.Env, EzPickle):
             NotImplementedError: If a render mode is requested.
         """
         EzPickle.__init__(
-            self, env_file, scenario, max_steps, render_mode, food_placement
+            self,
+            env_file,
+            scenario,
+            max_steps,
+            render_mode,
+            food_placement,
+            radar_model,
         )
         if scenario not in SCENARIOS:
             raise ValueError(f"scenario must be one of {SCENARIOS}, got {scenario!r}")
@@ -178,8 +190,9 @@ class DualTaskEnvV0(gym.Env, EzPickle):
         self.max_steps = int(max_steps)
         self.render_mode = render_mode
         self.food_placement = food_placement
+        self.radar_model = radar_model
 
-        self.env = Environment(self.env_file)
+        self.env = Environment(self.env_file, radar_model=radar_model)
         if self.env.aoi_rectangle is None:
             raise ValueError(f"{env_file} has no AOIRectangle; not a dual-task world")
         if self.env.max_distance <= 0.0:

--- a/src/gymnasium_hardmaze/envs/environment.py
+++ b/src/gymnasium_hardmaze/envs/environment.py
@@ -18,15 +18,18 @@ from .components.wall import Wall
 class Environment:
     """Environment for maze navigation."""
 
-    def __init__(self, xml_file: str):
+    def __init__(self, xml_file: str, radar_model: str = "corrected"):
         """Initialize the environment from an XML file.
 
         Args:
             xml_file: Path to the XML file or resource name under `gymnasium_hardmaze/data/`.
+            radar_model: Goal-sensor model handed to the robot; see
+                :data:`~gymnasium_hardmaze.envs.components.robot.RADAR_MODELS`.
 
         Raises:
             FileNotFoundError: If the XML file cannot be found.
         """
+        self.radar_model = radar_model
         # Resolve file path whether it's a relative path or a package resource
         if os.path.isfile(xml_file):
             with open(xml_file, encoding="utf-8") as f:
@@ -103,7 +106,7 @@ class Environment:
         """
         start = cast(Optional[Tag], soup.find("start_point"))
         if start is None:
-            self.robot = Robot((400.0, 700.0))
+            self.robot = Robot((400.0, 700.0), radar_model=self.radar_model)
             return
 
         x_tag = cast(Optional[Tag], start.find("x"))
@@ -114,7 +117,7 @@ class Environment:
         except (AttributeError, ValueError):
             start_x, start_y = 400.0, 700.0
 
-        self.robot = Robot((start_x, start_y))
+        self.robot = Robot((start_x, start_y), radar_model=self.radar_model)
 
     def init_goal(self, soup: bs4.BeautifulSoup) -> None:
         """Initialize the goal from the XML soup.

--- a/src/gymnasium_hardmaze/tests/test_dual_task_env.py
+++ b/src/gymnasium_hardmaze/tests/test_dual_task_env.py
@@ -7,6 +7,8 @@ import numpy as np
 import pytest
 
 import gymnasium_hardmaze  # noqa: F401  (registers DualTask-v0)
+from gymnasium_hardmaze.envs.components.goal import Goal
+from gymnasium_hardmaze.envs.components.robot import Robot
 from gymnasium_hardmaze.envs.dual_task_env import (
     DEFAULT_EVALUATION_STEPS,
     FOOD_RADIUS,
@@ -295,3 +297,65 @@ class TestFoodPlacement:
     def test_rejects_unknown_placement(self):
         with pytest.raises(ValueError, match="food_placement"):
             DualTaskEnvV0(food_placement="everywhere")
+
+
+class TestRadarModel:
+    """The reference goal sensor, and how it differs from the corrected one."""
+
+    def test_corrected_is_the_default(self):
+        env = DualTaskEnvV0(scenario="food_gathering")
+        assert env.radar_model == "corrected"
+        assert env.env.robot.radar_model == "corrected"
+        env.close()
+
+    def test_reference_survives_reset(self):
+        """Environment.reset() rebuilds the robot, so the model must persist."""
+        env = DualTaskEnvV0(scenario="food_gathering", radar_model="reference")
+        env.reset(seed=0)
+        assert env.env.robot.radar_model == "reference"
+        env.close()
+
+    def test_corrected_radar_is_a_compass(self):
+        """Exactly four wedge changes per revolution, in bearing order."""
+        robot = Robot((300.0, 400.0), radar_model="corrected")
+        goal = Goal(500.0, 400.0)
+        lit = []
+        for degree in range(360):
+            robot.heading = math.radians(degree)
+            robot.update_radars(goal)
+            values = [r.get_value() for r in robot.radars]
+            assert sum(values) == 1  # a compass lights exactly one wedge
+            lit.append(values.index(1))
+        changes = sum(lit[i] != lit[i - 1] for i in range(360))
+        assert changes == 4
+
+    def test_reference_radar_scrambles_the_bearing(self):
+        """The degrees-as-radians bug magnifies heading by ~57."""
+        robot = Robot((300.0, 400.0), radar_model="reference")
+        goal = Goal(500.0, 400.0)
+        lit = []
+        for degree in range(360):
+            robot.heading = math.radians(degree)
+            robot.update_radars(goal)
+            values = [r.get_value() for r in robot.radars]
+            assert sum(values) == 1
+            lit.append(values.index(1))
+        changes = sum(lit[i] != lit[i - 1] for i in range(360))
+        # 180/3.14 ~ 57 turns of the wedge per turn of the robot; a clean
+        # compass would change 4 times.
+        assert changes > 200
+
+    def test_reference_radar_is_deterministic_not_noisy(self):
+        """It is a scrambling, not randomness -- controllers can exploit it."""
+        robot = Robot((300.0, 400.0), radar_model="reference")
+        goal = Goal(500.0, 400.0)
+        readings = []
+        for _ in range(3):
+            robot.heading = math.radians(37.0)
+            robot.update_radars(goal)
+            readings.append([r.get_value() for r in robot.radars])
+        assert readings[0] == readings[1] == readings[2]
+
+    def test_rejects_unknown_radar_model(self):
+        with pytest.raises(ValueError, match="radar_model"):
+            Robot((0.0, 0.0), radar_model="ultrasound")


### PR DESCRIPTION
Stacked on #20 (base: `dual-task-random-food`) since both touch `dual_task_env.py`.

## The bug this exposes

Risi's `PieSliceSensorArray.update` computes its rotation amount in **degrees** and hands it to a `rotate()` that interprets **radians**, scaling the heading by `180/3.14 ≈ 57`. The pie-slice array is therefore not the goal-bearing compass it reads as — it is a deterministic scrambling of one.

Measured, robot at the maze start, goal at (190, 151):

| heading | true bearing | corrected wedge | reference wedge |
|---:|---:|:---|:---|
| 0° | 266.4° | right | right |
| 15° | 251.4° | right | left |
| 30° | 236.4° | right | front |
| 45° | 221.4° | rear | rear |
| 90° | 176.4° | rear | rear |
| 135° | 131.4° | left | left |
| 180° | 86.4° | left | front |
| 225° | 41.4° | front | front |
| 270° | 356.4° | front | right |
| 315° | 311.4° | right | rear |

Zoomed to 1° steps the magnification is visible directly — heading 0°→1° flips `right`→`rear`, 3°→`left`, 4°→`front`. Counting wedge changes across a full revolution in 1° steps: **corrected 4** (what a four-wedge compass must do), **reference 229**.

## Why it belongs in the package

This is not a curiosity, and it is not noise — the scrambling is deterministic, so a controller can exploit it as a strange but consistent function of position and heading. That is precisely what Risi's champions did: the hard maze reproduces the thesis **only** with the bug intact (20/20 at mean 143.7 generations under the reference sensor; the corrected sensor makes the task materially easier at 20/20 in 92.8).

The dual task has meanwhile been running on the corrected sensor, i.e. a clean always-on food compass, and the consequence is now measurable: **every fixed-substrate variant solves 20/20** where the paper reports 13/20 for its best (FS5x5). The ES-vs-FS separation the paper's argument rests on disappears. Without this option there is no way to test whether that separation returns under the sensor model the paper's results were actually produced with.

## What this PR does

- `radar_model = "corrected"` (default, existing behaviour) or `"reference"`, on `Robot`, `Environment` and `DualTaskEnvV0`.
- Threaded through `Environment` rather than set on the robot, because `Environment.reset()` rebuilds the robot — a post-construction assignment would be silently discarded on the first reset. There is a test for exactly that.
- The reference path reproduces the original arithmetic verbatim, including `Point2D.angle`'s `atan` over a half turn and `3.14` in place of pi.

## Validation

- **Bit-identical to an independently validated implementation**: checked against the `reference_maze.py` port (the one whose maze reproduction matches Risi's shipped champions genome-by-genome) across 1080 heading × position configurations — **0 mismatches**.
- Six new tests: corrected default; the model survives `reset()`; corrected gives exactly 4 wedge changes per revolution with exactly one wedge lit; reference gives >200; reference is deterministic across repeated reads; unknown models rejected.
- 45 tests pass. pre-commit clean (`pyright` verified separately against a venv with the deps, since `lxml` cannot build in the hook environment on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)